### PR TITLE
Fix Node.js CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,15 +16,16 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
+        cache: 'npm'
+    - run: npm install --legacy-peer-deps
     - name: Lint
       run: npm run lint
     - name: Build and Statically Render


### PR DESCRIPTION
- Upgrade to Node 18.x (from 12.x/14.x)
- Use npm install --legacy-peer-deps instead of npm ci
- Update to actions/checkout@v4 and actions/setup-node@v4
- Add npm caching

https://claude.ai/code/session_01APBXUNvh6TcdyQct3yV2Wn