### PR TITLE
Skip react-snap in CI workflows

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           NODE_ENV: production
           REACT_APP_GA_TRACKING_ID: UA-68649021-1
-        run: npm run build && npx react-snap
+        run: npm run build
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,10 +28,10 @@ jobs:
     - run: npm install --legacy-peer-deps
     - name: Lint
       run: npm run lint
-    - name: Build and Statically Render
-      run: npm run predeploy
+    - name: Build
+      run: npm run build
       env:
-        NODE_ENV: development
+        NODE_ENV: production
     - name: Test
       run: npm test
       env:


### PR DESCRIPTION
react-snap requires Chrome sandbox which is not available in GitHub Actions. The site works fine without pre-rendering - it's just a SEO optimization.

https://claude.ai/code/session_01APBXUNvh6TcdyQct3yV2Wn