### PR TITLE
Update positioning: Software Engineer + Quantitative Finance

### DIFF
--- a/src/components/Template/SideBar.js
+++ b/src/components/Template/SideBar.js
@@ -12,7 +12,8 @@ const SideBar = () => (
       </Link>
       <header>
         <h2>Hidai Bar-Mor</h2>
-        <p>AI/ML Engineer</p>
+        <p>Software Engineer</p>
+        <p className="sidebar-subtitle">Quantitative Finance</p>
         <p><a href="mailto:hidai25@gmail.com">hidai25@gmail.com</a></p>
       </header>
     </section>

--- a/src/data/about.md
+++ b/src/data/about.md
@@ -1,28 +1,39 @@
 
 # Intro
 
-I am an AI/ML engineer and software developer with a strong foundation in quantitative finance. I build intelligent systems that solve real-world problems, from LLM-powered applications to data-driven trading strategies. I'm passionate about leveraging cutting-edge AI technologies to create impactful products.
-
-# Currently
-
-Building AI-powered applications and evaluation frameworks while working as a trader at Mizrahi Tefahot Bank in Tel-Aviv. I focus on applying machine learning and large language models to both financial markets and software products.
+Software engineer with deep expertise in quantitative finance. I build intelligent systems that bridge the gap between complex financial problems and modern technology solutions.
 
 # Background
 
-With over 15 years of experience in quantitative finance across major institutions including Fortis Bank and Mizrahi Tefahot Bank, I've developed a unique perspective on applying technology to complex problems. My transition into software engineering through Harvard Extension School has enabled me to bridge the gap between domain expertise and modern AI/ML capabilities.
+**15+ years in quantitative finance** across major institutions:
+- **Mizrahi Tefahot Bank** - Quantitative Developer & Trader
+- **Rodman Barney** - Head Trader
+- **Fortis Bank** (now BNP Paribas) - Credit Derivatives Trader
 
-# What I Build
-
-- **LLM Applications**: End-to-end systems using OpenAI, LangChain, and RAG architectures
-- **ML Pipelines**: Production-grade machine learning workflows for prediction and analysis
-- **Data Products**: Full-stack applications that turn data into actionable insights
-- **Evaluation Tools**: Frameworks for measuring and improving AI system performance
+This experience gave me a unique perspective on building systems that handle real-world complexity, risk, and scale.
 
 # Education
 
-- **Harvard Extension School** - Master of Liberal Arts, Software Engineering (2023)
-- **University of Liege, Belgium** - B.A. Economical Sciences (2006)
+- **Harvard Extension School** - ALM, Software Engineering (2023)
+- **University of Liege, Belgium** - B.A. Economics (2006)
 
-# Technical Focus
+# Technical Expertise
 
-My current technical interests center around building reliable AI systems: prompt engineering, retrieval-augmented generation, model evaluation, and deploying ML models at scale. I'm particularly interested in the intersection of AI and financial technology.
+**AI/ML Engineering**
+- Large Language Models (LLMs), prompt engineering, RAG systems
+- Model evaluation and MLOps
+- Python, PyTorch, LangChain, OpenAI API
+
+**Software Development**
+- Full-stack: React, Node.js, FastAPI
+- Data engineering: SQL, Spark, ETL pipelines
+- Cloud: AWS, GCP, Docker
+
+**Quantitative Finance**
+- Derivatives pricing and risk modeling
+- Algorithmic trading systems
+- Statistical analysis and forecasting
+
+# What I Build
+
+Systems that combine domain expertise with engineering rigor: AI-powered analytics tools, evaluation frameworks, and applications that turn complex data into actionable insights.

--- a/src/pages/Index.js
+++ b/src/pages/Index.js
@@ -6,9 +6,9 @@ import Main from '../layouts/Main';
 const Index = () => (
   <Main
     description={
-      'Hidai Bar-Mor - AI/ML Engineer building LLM applications, '
-      + 'evaluation frameworks, and data products. Harvard Extension School '
-      + 'graduate with 15+ years in quantitative finance.'
+      'Hidai Bar-Mor - Software Engineer & Quantitative Finance Professional. '
+      + 'Harvard ALM in Software Engineering. Building AI/ML applications '
+      + 'at the intersection of technology and financial markets.'
     }
   >
     <article className="post" id="index">
@@ -17,34 +17,34 @@ const Index = () => (
           <h2 data-testid="heading">
             <Link to="/">Hidai Bar-Mor</Link>
           </h2>
-          <p>AI/ML Engineer</p>
+          <p>Software Engineer | Quantitative Finance</p>
         </div>
       </header>
       <p>
-        I build AI-powered products that solve real problems. From LLM evaluation
-        frameworks to ML-driven analytics platforms, I focus on shipping tools
-        that deliver measurable impact.
+        I build intelligent systems at the intersection of finance and technology.
+        With 15+ years trading derivatives and managing risk at major financial
+        institutions, I now apply that domain expertise to software engineering
+        and AI/ML development.
       </p>
       <p>
-        With 15+ years in quantitative finance and a Master&apos;s in Software
-        Engineering from{' '}
-        <a href="https://extension.harvard.edu/">Harvard Extension School</a>,
-        I bring a unique blend of technical depth and business acumen to
-        every project.
+        <strong>Background:</strong> Master&apos;s in Software Engineering from{' '}
+        <a href="https://extension.harvard.edu/">Harvard Extension School</a>.
+        Former derivatives trader at Fortis Bank and quantitative developer at
+        Mizrahi Tefahot Bank.
       </p>
       <p>
-        <strong>What I do:</strong> LLM applications, prompt engineering,
-        RAG systems, ML pipelines, full-stack development.
+        <strong>Focus areas:</strong> AI/ML applications, LLM systems, quantitative
+        modeling, full-stack development, and data engineering.
       </p>
       <ul className="actions">
         <li>
           <Link to="/projects" className="button">
-            View My Work
+            View Projects
           </Link>
         </li>
         <li>
-          <Link to="/about" className="button">
-            Learn More
+          <Link to="/resume" className="button">
+            Resume
           </Link>
         </li>
       </ul>


### PR DESCRIPTION
- Homepage: "Software Engineer | Quantitative Finance" tagline
- Sidebar: Dual title showing both roles
- About: Restructured to highlight finance background + technical skills
- More professional, executive-level positioning

https://claude.ai/code/session_01APBXUNvh6TcdyQct3yV2Wn